### PR TITLE
Add cursor: pointer on web for all Pressable elements

### DIFF
--- a/SoccerPoolsMobile/app/_layout.tsx
+++ b/SoccerPoolsMobile/app/_layout.tsx
@@ -39,6 +39,10 @@ export default function Layout () {
         if (Platform.OS === 'web') {
             vexoWeb();
             initializeGoogleAds();
+
+            const style = document.createElement('style');
+            style.textContent = '[role="button"] { cursor: pointer; }';
+            document.head.appendChild(style);
         }
     }, []);
 


### PR DESCRIPTION
Injects a global CSS rule targeting [role="button"] (how react-native-web
renders Pressable) so all interactive elements show a pointer cursor on web.
Runs only inside the existing Platform.OS === 'web' guard, no mobile impact.

https://claude.ai/code/session_01KzqHVTSrQfwAY6GERFuhoy