### PR TITLE
Add Android 16 KB page size support via config plugin

### DIFF
--- a/SoccerPoolsMobile/app.json
+++ b/SoccerPoolsMobile/app.json
@@ -56,10 +56,12 @@
           "android": {
             "compileSdkVersion": 35,
             "targetSdkVersion": 35,
-            "buildToolsVersion": "35.0.0"
+            "buildToolsVersion": "35.0.0",
+            "useLegacyPackaging": false
           }
         }
-      ]
+      ],
+      "./plugins/withAndroid16KBPages"
     ],
     "extra": {
       "eas": {

--- a/SoccerPoolsMobile/plugins/withAndroid16KBPages.js
+++ b/SoccerPoolsMobile/plugins/withAndroid16KBPages.js
@@ -1,0 +1,16 @@
+const { withAndroidManifest } = require('expo/config-plugins');
+
+/**
+ * Config plugin to support 16 KB memory page sizes on Android.
+ * Sets android:extractNativeLibs="false" in AndroidManifest.xml so native
+ * libraries are loaded directly from the APK with proper page alignment.
+ */
+const withAndroid16KBPages = (config) => {
+  return withAndroidManifest(config, (config) => {
+    const mainApplication = config.modResults.manifest.application[0];
+    mainApplication.$['android:extractNativeLibs'] = 'false';
+    return config;
+  });
+};
+
+module.exports = withAndroid16KBPages;


### PR DESCRIPTION
## Summary
This PR adds support for Android devices with 16 KB memory page sizes by implementing a custom Expo config plugin that disables native library extraction from the APK.

## Key Changes
- **New config plugin** (`withAndroid16KBPages.js`): Created a custom Expo config plugin that sets `android:extractNativeLibs="false"` in the AndroidManifest.xml. This allows native libraries to be loaded directly from the APK with proper page alignment, enabling compatibility with 16 KB page size devices.
- **Updated app.json**: 
  - Registered the new config plugin in the plugins array
  - Added `useLegacyPackaging: false` to the Android build configuration to work in conjunction with the native library extraction setting

## Implementation Details
The config plugin uses Expo's `withAndroidManifest` utility to modify the manifest at build time. By setting `extractNativeLibs` to false, native libraries remain in the APK and are loaded with the correct alignment for 16 KB page size support, which is required for compatibility with newer Android devices.

https://claude.ai/code/session_012PbYosYkvbaw1pbhrxzqJq