### PR TITLE
Fix absolute imports by completing tsconfig.json path aliases and inc…

### DIFF
--- a/SoccerPoolsMobile/tsconfig.json
+++ b/SoccerPoolsMobile/tsconfig.json
@@ -5,7 +5,25 @@
     "paths": {
       "components/*": ["./components/*"],
       "utils/*": ["./utils/*"],
+      "hooks/*": ["./hooks/*"],
+      "services/*": ["./services/*"],
+      "contexts/*": ["./contexts/*"],
+      "modals/*": ["./modals/*"],
+      "theme": ["./theme/index"],
+      "theme/*": ["./theme/*"]
     }
   },
-  "include": ["types.d.ts", "components", "app", "utils"]
+  "include": [
+    "types.d.ts",
+    "types.ts",
+    "constants.ts",
+    "components",
+    "app",
+    "utils",
+    "hooks",
+    "services",
+    "contexts",
+    "modals",
+    "theme"
+  ]
 }


### PR DESCRIPTION
…ludes

Added missing path aliases for hooks, services, contexts, modals, and theme so TypeScript resolves bare imports (e.g. `import X from 'hooks/useUser'`) without errors. Also expanded the include list to cover all source directories so TypeScript type-checks the full codebase.

babel-preset-expo reads these paths from tsconfig.json and configures Metro accordingly, so no additional Babel plugin is needed.

https://claude.ai/code/session_01XmsoRHr8gTWtiAaimYzD46